### PR TITLE
Adding in static front page check for homepage meta description plugin

### DIFF
--- a/Plugin/FishPig_WordPress/Model/HomepagePlugin.php
+++ b/Plugin/FishPig_WordPress/Model/HomepagePlugin.php
@@ -35,6 +35,10 @@ class HomepagePlugin extends AbstractPlugin
 	**/
 	protected function _aroundGetMetaDescription(ViewableInterface $object)
 	{
+        if ($object->getFrontStaticPage()) {
+            return $object->getFrontStaticPage()->getMetaDescription();
+        }
+        
 		return $this->_rewriteString(
 			$this->_getMetaDescriptionFormat('home_wpseo')
 		);


### PR DESCRIPTION
Adding in front static page check to the _aroundGetMetaDescription function similar to the check in the _aroundGetPageTitle function